### PR TITLE
Missing *

### DIFF
--- a/spotify_monitor.py
+++ b/spotify_monitor.py
@@ -3451,7 +3451,7 @@ def main():
         SONG_ON_LOOP_NOTIFICATION = False
         ERROR_NOTIFICATION = False
 
-    print(f"* Spotify polling intervals:\t[check: {display_time(SPOTIFY_CHECK_INTERVAL)}] [inactivity: {display_time(SPOTIFY_INACTIVITY_CHECK)}]\n\t\t\t\t[disappeared: {display_time(SPOTIFY_DISAPPEARED_CHECK_INTERVAL)}] [error: {display_time(SPOTIFY_ERROR_INTERVAL)}]")
+    print(f"* Spotify polling intervals:\t[check: {display_time(SPOTIFY_CHECK_INTERVAL)}] [inactivity: {display_time(SPOTIFY_INACTIVITY_CHECK)}]\n*\t\t\t\t[disappeared: {display_time(SPOTIFY_DISAPPEARED_CHECK_INTERVAL)}] [error: {display_time(SPOTIFY_ERROR_INTERVAL)}]")
     print(f"* Email notifications:\t\t[active = {ACTIVE_NOTIFICATION}] [inactive = {INACTIVE_NOTIFICATION}] [tracked = {TRACK_NOTIFICATION}]\n*\t\t\t\t[songs on loop = {SONG_ON_LOOP_NOTIFICATION}] [every song = {SONG_NOTIFICATION}] [errors = {ERROR_NOTIFICATION}]")
     print(f"* Token source:\t\t\t{TOKEN_SOURCE}")
     print(f"* Track listened songs:\t\t{TRACK_SONGS}")


### PR DESCRIPTION
There was a missing * in the information printed when first loading the app. There was a left * on the 2nd line underneath Email Notifications but not Spotify Polling Intervals

```
* Spotify polling intervals:    [check: 30 seconds] [inactivity: 8 minutes]
*                               [disappeared: 3 minutes] [error: 3 minutes]
* Email notifications:          [active = True] [inactive = True] [tracked = True]
*                               [songs on loop = True] [every song = True] [errors = True]
* Token source:                 cookie
* Track listened songs:         False
```