### PR TITLE
Added feature to limit line widths printed to screen to avoid line wrapping

### DIFF
--- a/spotify_monitor.py
+++ b/spotify_monitor.py
@@ -3459,7 +3459,7 @@ def main():
                 TRUNCATE_CHARS = terminal_size.columns
                 
             except Exception as e:
-                print("Cannot determine terminal screen width.")
+                print(f"Cannot determine terminal screen width: {e}")
                 sys.exit(1)
     
     if args.notify_active is True:

--- a/spotify_monitor.py
+++ b/spotify_monitor.py
@@ -3454,8 +3454,8 @@ def main():
         else:
             try:
                 terminal_size = shutil.get_terminal_size()
-                print_to_log(f"The terminal screen width is: {terminal_size.columns} characters")
-                print_to_log(f"")
+                print(f"The detected terminal screen width is: {terminal_size.columns} characters")
+                print(f"")
                 TRUNCATE_CHARS = terminal_size.columns
                 
             except Exception as e:

--- a/spotify_monitor.py
+++ b/spotify_monitor.py
@@ -3130,7 +3130,7 @@ def main():
         help="Disable logging to spotify_monitor_<user_uri_id/file_suffix>.log"
     )
     opts.add_argument(
-        "-n", "--truncate",
+        "-tr", "--truncate",
         dest="truncate",
         type=int,
         help="Truncate screen output (not log) to this # of characters. '999' will autodetect and use the screen width"

--- a/spotify_monitor.py
+++ b/spotify_monitor.py
@@ -234,6 +234,11 @@ TOKEN_MAX_RETRIES = 10
 # Used only when the token source is set to 'cookie'
 TOKEN_RETRY_TIMEOUT = 0.5  # 0.5 second
 
+# Limit the number of characters on each line printed to the screen to eliminate line-wrapping
+# This does not impact what is written to the log file.
+# A value of 999 will autodetect the screen width and use that width for the truncation
+TRUNCATE_CHARS = 0
+
 # ---------------------------------------------------------------------
 
 # The section below is used when the token source is set to 'client'


### PR DESCRIPTION
I developed some simple code to limit the line widths printed to the screen to avoid line wrapping.
I find this useful when running a vertical split screen with two instances running.
I've tested it under Windows in both a standard command window and Terminal with a split screen.
The code is operating system independent.
_A value of 999 will autodetect the screen width and use that width for the truncation_

**Note: Logging is not impacted, and the full strings are written to the log file.**

I realize that this PR may not be of general interest for you to merge. No issue if so. I'm just sharing some code that might improve someone's experience.