### PR TITLE
Fix truncation code to handle emojis with a actual width greater than one character. Example: 🎧

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ python-dateutil
 urllib3
 pyotp
 python-dotenv
+wcwidth

--- a/spotify_monitor.py
+++ b/spotify_monitor.py
@@ -534,6 +534,7 @@ from pathlib import Path
 import secrets
 from typing import Optional
 from email.utils import parsedate_to_datetime
+from wcwidth import wcwidth
 
 import urllib3
 if not VERIFY_SSL:

--- a/spotify_monitor.py
+++ b/spotify_monitor.py
@@ -561,14 +561,25 @@ SESSION.mount("http://", adapter)
 
 
 # Truncates each line of a string to a specified number of characters including tab expansion and multi-line support
-def truncate_string_per_line(message, truncate_chars, tabsize=8):
+def truncate_string_per_line(message, truncate_width, tabsize=8):
     lines = message.split('\n')
     truncated_lines = []
 
     for line in lines:
-        expanded_line = line.expandtabs(tabsize=tabsize)
-        truncated_line = expanded_line[:truncate_chars]
-        truncated_lines.append(truncated_line)
+        expanded_line = line.expandtabs(tabsize)
+        current_width = 0
+        truncated = ''
+
+        for char in expanded_line:
+            char_width = wcwidth(char)
+            if char_width < 0:
+                char_width = 0  # Non-printable or unknown width
+            if current_width + char_width > truncate_width:
+                break
+            truncated += char
+            current_width += char_width
+
+        truncated_lines.append(truncated)
 
     return '\n'.join(truncated_lines)
 


### PR DESCRIPTION
I noticed today that the truncation code doesn't cover the case when some emojis take up two character positions (they are double-wide). An example is the following, which was in the title of a playlist in my log: 🎧

This code does a character-by-character analysis and accounts for this.