### PR TITLE
Remove message that should never trigger

### DIFF
--- a/spotify_monitor.py
+++ b/spotify_monitor.py
@@ -2496,9 +2496,6 @@ def spotify_monitor_friend_uri(user_uri_id, tracks, csv_file_name):
                 sp_active_ts_stop = sp_ts
                 print(f"\n*** Friend is OFFLINE for: {calculate_timespan(int(cur_ts), int(sp_ts))}")
 
-            if listened_songs:
-                print(f"\nSongs played:\t\t\t{listened_songs} ({calculate_timespan(int(sp_ts), int(sp_active_ts_start))})")
-
             print(f"\nTracks/playlists/albums to monitor: {tracks}")
             print_cur_ts("\nTimestamp:\t\t\t")
 


### PR DESCRIPTION
This message was not included in my original PR, as it's only executed when the script is first started and only if the user is offline/inactive. In that case, this message should never be triggered because the `listened_songs` count will be 0, as the user hasn't listened to any songs yet.

I offer this PR to clean things up.