### PR TITLE
Delete flag_file at launch if specified via .conf file. Currently only done when flag_file specified on command line

### DIFF
--- a/spotify_monitor.py
+++ b/spotify_monitor.py
@@ -3374,6 +3374,7 @@ def main():
     else:
         if FLAG_FILE:
             FLAG_FILE = os.path.expanduser(FLAG_FILE)
+            flag_file_delete()
 
     if args.send_test_email:
         print("* Sending test email notification ...\n")


### PR DESCRIPTION
Remove any existing/stale/old FLAG_FILE before determining whether user is active