### PR TITLE
Remove walrus operator to support min python version 3.6

### DIFF
--- a/spotify_monitor.py
+++ b/spotify_monitor.py
@@ -1282,7 +1282,8 @@ def fetch_server_time(session: req.Session, ua: str) -> int:
 def generate_totp():
     import pyotp
 
-    if str((ver := TOTP_VER or max(map(int, SECRET_CIPHER_DICT)))) not in SECRET_CIPHER_DICT:
+    ver = TOTP_VER or max(map(int, SECRET_CIPHER_DICT))
+    if str(ver) not in SECRET_CIPHER_DICT:
         raise Exception(f"generate_totp(): Defined TOTP_VER ({ver}) is missing in SECRET_CIPHER_DICT")
 
     secret_cipher_bytes = SECRET_CIPHER_DICT[str(ver)]


### PR DESCRIPTION
The walrus operator (:=) was introduced in python 3.8.
So, either it should be removed, or the minimum version should be 3.8

Current code base checks for 3.6:
```
if sys.version_info < (3, 6):
    print("* Error: Python version 3.6 or higher required !")
    sys.exit(1)
```