### PR TITLE
Indicate if a playlist is a Spotify curated public one

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "spotify_monitor"
-version = "2.8"
+version = "2.9"
 description = "Track Spotify friends' music activity in real time with auto-playback, skipped tracks detection and instant notifications"
 readme = "README.md"
 license = "GPL-3.0-or-later"

--- a/spotify_monitor.py
+++ b/spotify_monitor.py
@@ -320,7 +320,7 @@ ENABLE_LYRICS_COM_URL = False
 # String to add after playlist name to indicate it's a Spotify public curated and customized playlist
 # The distinction may be important because the songs will vary by account due to listening habits.
 # This will be used for messages on console and emails
-# Include all characters, including a preceeding space and paranthesis if desired
+# The string should include all desired characters, including a preceding space and parenthesis, if desired
 #
 # Example: 
 #   For: 90s Pop (Spotify curated), SPOTIFY_SUFFIX = " (Spotify curated)"

--- a/spotify_monitor.py
+++ b/spotify_monitor.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """
 Author: Michal Szymanski <misiektoja-github@rm-rf.ninja>
-v2.8
+v2.9
 
 Tool implementing real-time tracking of Spotify friends music activity:
 https://github.com/misiektoja/spotify_monitor/
@@ -17,7 +17,7 @@ wcwidth (optional, needed by TRUNCATE_CHARS feature)
 spotipy (required since v2.7 due to new Spotify restrictions introduced on 22 Dec 2025)
 """
 
-VERSION = "2.8"
+VERSION = "2.9"
 
 # ---------------------------
 # CONFIGURATION SECTION START
@@ -324,9 +324,8 @@ ENABLE_LYRICS_COM_URL = False
 #
 # Example:
 #   For: 90s Pop (by Spotify), SPOTIFY_SUFFIX = " (by Spotify)"
-#   For: 90s Pop ♥,            SPOTIFY_SUFFIX = " \u2665"
 #
-# Use "" to disable
+# Leave empty to disable
 SPOTIFY_SUFFIX = ""
 
 # ---------------------------------------------------------------------

--- a/spotify_monitor.py
+++ b/spotify_monitor.py
@@ -323,8 +323,8 @@ ENABLE_LYRICS_COM_URL = False
 # The string should include all desired characters, including a preceding space and parenthesis, if desired
 #
 # Example: 
-#   For: 90s Pop (Spotify curated), SPOTIFY_SUFFIX = " (Spotify curated)"
-#   For: 90s Pop (custom),          SPOTIFY_SUFFIX = " (custom)"
+#   For: 90s Pop (by Spotify), SPOTIFY_SUFFIX = " (by Spotify)"
+#   For: 90s Pop ♥,            SPOTIFY_SUFFIX = " \u2665"
 #
 # Use "" to disable
 SPOTIFY_SUFFIX = ""


### PR DESCRIPTION
Spotify curated public playlists vary by account depending on listening habits. This adds a way to know if a specific playlist reported for an account is one of these. Many times, the names of the playlists are not obviously Spotify ones

This will be used for messages on console and emails
The string should Include all desired characters, including a preceding space and parentheses if desired

Emojis should work, but I didn't test them
```
Example: 
   For: 90s Pop (Spotify curated), SPOTIFY_SUFFIX = " (Spotify curated)"
   For: 90s Pop (custom),          SPOTIFY_SUFFIX = " (custom)"
```

In use at startup:
```
Playlist:			Feel Good Dinner (custom)
Album:				Sugar at the Gate
```

Note that I used to have two labels for this.
- Custom indicated the playlist was custom
- Unique was added after to indicate if the song was shared with the current user or not (is it unique?)

However, with the recent change, you cannot look at the contents of a Spotify playlist to check whether or not there is a similarity with the current account
```
Playlist:			Feel Good Dinner (custom)(unique)
Album:				Sugar at the Gate
```
 
