### PR TITLE
Support TRUNCATE_CHARS in .conf file with 999 support (was broken if …

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -17,6 +17,7 @@ Version **3.2** adds **Spotify-to-Last.fm scrobble health monitoring** plus flex
 
 **Bug fixes**:
 
+- **BUGFIX:** Applied terminal-width auto-detection when `TRUNCATE_CHARS = 999` comes from configuration while preserving `--truncate` precedence and skipping truncation when logging is disabled (thanks [@tomballgithub](https://github.com/tomballgithub), [#45](https://github.com/misiektoja/spotify_monitor/pull/45))
 - **BUGFIX:** Kept long ntfy text notifications below the server's 4 KB attachment boundary and added a visible truncation marker
 - **BUGFIX:** Made `SIGHUP` clear cached Spotify authentication after credential rotation and redetect Discord or ntfy when the private webhook destination changes
 

--- a/spotify_monitor.py
+++ b/spotify_monitor.py
@@ -8407,16 +8407,16 @@ def main():
             FILE_SUFFIX = str(target_user_id)
 
     if args.truncate:
-        if args.truncate != 999:
-            TRUNCATE_CHARS = args.truncate
-        else:
-            try:
-                terminal_size = shutil.get_terminal_size()
-                print(f"The detected terminal screen width is: {terminal_size.columns} characters\n")
-                TRUNCATE_CHARS = terminal_size.columns
-            except Exception as e:
-                print(f"Error: Cannot determine terminal screen width: {e}")
-                sys.exit(1)
+        TRUNCATE_CHARS = args.truncate
+
+    if TRUNCATE_CHARS == 999:
+        try:
+            terminal_size = shutil.get_terminal_size()
+            print_to_screen(f"The detected terminal screen width is: {terminal_size.columns} characters\n")
+            TRUNCATE_CHARS = terminal_size.columns
+        except Exception as e:
+            print(f"Error: Cannot determine terminal screen width: {e}")
+            sys.exit(1)
 
     if args.disable_logging is True:
         DISABLE_LOGGING = True

--- a/spotify_monitor.py
+++ b/spotify_monitor.py
@@ -8412,7 +8412,7 @@ def main():
     if TRUNCATE_CHARS == 999:
         try:
             terminal_size = shutil.get_terminal_size()
-            print_to_screen(f"The detected terminal screen width is: {terminal_size.columns} characters\n")
+            print(f"The detected terminal screen width is: {terminal_size.columns} characters\n")
             TRUNCATE_CHARS = terminal_size.columns
         except Exception as e:
             print(f"Error: Cannot determine terminal screen width: {e}")

--- a/spotify_monitor.py
+++ b/spotify_monitor.py
@@ -2272,6 +2272,18 @@ def truncate_string_per_line(message, truncate_width, tabsize=8):
     return '\n'.join(truncated_lines)
 
 
+# Resolves CLI and configured truncation settings while expanding the terminal-width sentinel
+def resolve_truncate_chars(cli_value, configured_value, logging_disabled):
+    truncate_chars = configured_value if cli_value is None else cli_value
+    if logging_disabled:
+        return 0
+    if truncate_chars == 999:
+        terminal_size = shutil.get_terminal_size()
+        print(f"The detected terminal screen width is: {terminal_size.columns} characters\n")
+        return terminal_size.columns
+    return truncate_chars
+
+
 # Logger class to output messages to stdout and log file
 class Logger(object):
     def __init__(self, filename):
@@ -9464,20 +9476,14 @@ def main():
             else:
                 FILE_SUFFIX = str(target_user_id)
 
-    if args.truncate:
-        TRUNCATE_CHARS = args.truncate
-
-    if TRUNCATE_CHARS == 999:
-        try:
-            terminal_size = shutil.get_terminal_size()
-            print(f"The detected terminal screen width is: {terminal_size.columns} characters\n")
-            TRUNCATE_CHARS = terminal_size.columns
-        except Exception as e:
-            print(f"Error: Cannot determine terminal screen width: {e}")
-            sys.exit(1)
-
     if args.disable_logging is True:
         DISABLE_LOGGING = True
+
+    try:
+        TRUNCATE_CHARS = resolve_truncate_chars(args.truncate, TRUNCATE_CHARS, DISABLE_LOGGING)
+    except OSError as e:
+        print(f"Error: Cannot determine terminal screen width: {e}")
+        sys.exit(1)
 
     if not DISABLE_LOGGING:
         try:

--- a/tests/test_startup_ui.py
+++ b/tests/test_startup_ui.py
@@ -420,6 +420,28 @@ def test_startup_summaries_never_include_secrets(monkeypatch, tmp_path):
         assert secret not in combined
 
 
+# Verifies configured terminal-width autodetection resolves the sentinel before logging starts
+def test_configured_truncation_autodetects_terminal_width(monkeypatch, capsys):
+    monkeypatch.setattr(monitor.shutil, "get_terminal_size", lambda: Mock(columns=120))
+    assert monitor.resolve_truncate_chars(None, 999, False) == 120
+    assert capsys.readouterr().out == "The detected terminal screen width is: 120 characters\n\n"
+
+
+# Verifies CLI truncation values take precedence including an explicit zero
+@pytest.mark.parametrize(("cli_value", "configured_value", "expected"), ((0, 80, 0), (72, 999, 72), (None, 80, 80)))
+def test_cli_truncation_overrides_configured_value(cli_value, configured_value, expected):
+    assert monitor.resolve_truncate_chars(cli_value, configured_value, False) == expected
+
+
+# Verifies disabled logging suppresses truncation and terminal-width detection
+def test_disabled_logging_skips_truncation_autodetection(monkeypatch, capsys):
+    terminal_size = Mock(side_effect=AssertionError("terminal width should not be detected"))
+    monkeypatch.setattr(monitor.shutil, "get_terminal_size", terminal_size)
+    assert monitor.resolve_truncate_chars(None, 999, True) == 0
+    terminal_size.assert_not_called()
+    assert capsys.readouterr().out == ""
+
+
 # Verifies terminal-only and log-only routing retain truncation and tab semantics
 def test_logger_terminal_only_and_log_only(monkeypatch, tmp_path):
     terminal = io.StringIO()


### PR DESCRIPTION
The 999 screen size check was only working if the command line switch was used.
This PR allows TRUNCATE_CHARS to be set in the .conf file and 999 works