### PR TITLE
Improve StartupSummaryRow for notifications for email/webhook

### DIFF
--- a/spotify_monitor.py
+++ b/spotify_monitor.py
@@ -4142,12 +4142,8 @@ def build_startup_summary(target: str, config_path, env_path, output_path) -> Li
     authentication = "Client mode, advanced" if TOKEN_SOURCE == "client" else "Cookie mode"
     enabled_notifications = _startup_notification_categories()
     enabled_webhooks = _startup_webhook_notification_categories()
-    if enabled_notifications and enabled_webhooks:
-        notification_state = "On (email: " + ", ".join(enabled_notifications) + " | webhook: " + ", ".join(enabled_webhooks) + ")"
-    elif enabled_webhooks:
-        notification_state = "On (webhook: " + ", ".join(enabled_webhooks) + ")"
-    else:
-        notification_state = "Off" if not enabled_notifications else "On (" + ", ".join(enabled_notifications) + ")"
+    notification_state_email =   "On (" + ", ".join(enabled_notifications) + ")" if enabled_notifications else "Off"
+    notification_state_webhook = "On (" + ", ".join(enabled_webhooks)      + ")" if enabled_webhooks      else "Off"
     output_state = str(output_path) if output_path else "Terminal only (logging disabled)"
     rows = [
         StartupSummaryRow("Target", str(target), concise=True),
@@ -4157,7 +4153,8 @@ def build_startup_summary(target: str, config_path, env_path, output_path) -> Li
         StartupSummaryRow("Inactivity timer", display_time(SPOTIFY_INACTIVITY_CHECK), concise=False),
         StartupSummaryRow("Disappeared timer", display_time(SPOTIFY_DISAPPEARED_CHECK_INTERVAL), concise=False),
         StartupSummaryRow("Error retry timer", display_time(SPOTIFY_ERROR_INTERVAL), concise=False),
-        StartupSummaryRow("Notifications", notification_state, concise=True, full=False, log=False),
+        StartupSummaryRow("Notifications (email)", notification_state_email, concise=True, full=False, log=False),
+        StartupSummaryRow("Notifications (webhook)", notification_state_webhook, concise=True, full=False, log=False),
         StartupSummaryRow("Notify active", str(ACTIVE_NOTIFICATION), concise=False),
         StartupSummaryRow("Notify inactive", str(INACTIVE_NOTIFICATION), concise=False),
         StartupSummaryRow("Notify monitored tracks", str(TRACK_NOTIFICATION), concise=False),

--- a/tests/test_startup_ui.py
+++ b/tests/test_startup_ui.py
@@ -193,7 +193,8 @@ def test_concise_summary_core_rows(monkeypatch):
     assert "target.user" in lines[0]
     assert "* Authentication:" in output and "Cookie mode" in output
     assert "* Polling interval:" in output and "30 seconds" in output
-    assert "* Notifications:" in output and "Off" in output
+    assert any(l.startswith("* Notifications (email):") and "Off" in l for l in lines)
+    assert any(l.startswith("* Notifications (webhook):") and "Off" in l for l in lines)
     assert "* Output:" in output and "spotify_monitor_target.user.log" in output
     assert "* Config:" in output and "/data/spotify_monitor.conf" in output
     assert "* Dotenv:" in output and "/data/.env" in output

--- a/tests/test_startup_ui.py
+++ b/tests/test_startup_ui.py
@@ -193,12 +193,23 @@ def test_concise_summary_core_rows(monkeypatch):
     assert "target.user" in lines[0]
     assert "* Authentication:" in output and "Cookie mode" in output
     assert "* Polling interval:" in output and "30 seconds" in output
-    assert any(l.startswith("* Notifications (email):") and "Off" in l for l in lines)
-    assert any(l.startswith("* Notifications (webhook):") and "Off" in l for l in lines)
     assert "* Output:" in output and "spotify_monitor_target.user.log" in output
     assert "* Config:" in output and "/data/spotify_monitor.conf" in output
     assert "* Dotenv:" in output and "/data/.env" in output
     assert "* Metadata backend:" in output and "web player" in output
+
+
+# Verifies concise notification rows keep email and webhook states independent
+@pytest.mark.parametrize("email_enabled,webhook_category_enabled,webhook_master_enabled,expected_email,expected_webhook", [(False, False, False, "Off", "Off"), (True, False, False, "On (active, monitored tracks)", "Off"), (False, True, True, "Off", "On (active, errors)"), (True, True, True, "On (active, monitored tracks)", "On (active, errors)"), (False, True, False, "Off", "Off")])
+def test_concise_summary_notification_channels(monkeypatch, email_enabled, webhook_category_enabled, webhook_master_enabled, expected_email, expected_webhook):
+    configure_summary(monkeypatch)
+    monkeypatch.setattr(monitor, "ACTIVE_NOTIFICATION", email_enabled)
+    monkeypatch.setattr(monitor, "TRACK_NOTIFICATION", email_enabled)
+    monkeypatch.setattr(monitor, "WEBHOOK_ACTIVE_NOTIFICATION", webhook_category_enabled)
+    monkeypatch.setattr(monitor, "WEBHOOK_ERROR_NOTIFICATION", webhook_category_enabled)
+    monkeypatch.setattr(monitor, "WEBHOOK_ENABLED", webhook_master_enabled)
+    notification_lines = [line for line in emit_to_string(summary_rows()).splitlines() if line.startswith("* Notifications (")]
+    assert notification_lines == [f"* Notifications (email):     {expected_email}", f"* Notifications (webhook):   {expected_webhook}"]
 
 
 # Verifies disabled advanced defaults stay out of the concise view


### PR DESCRIPTION
I thought the previous display for this information was cluttered and too long, line wrapping on my terminal
I think this looks cleaner

Previous style:
`* Notifications:             On (email: active, inactive, monitored tracks, every song, songs on loop, errors | webhook: active, inactive, monitored tracks, every song, songs on loop, errors)
`

This-PR style:
```
* Notifications (email):     On (active, inactive, monitored tracks, every song, songs on loop, errors)
* Notifications (webhook):   On (active, inactive, monitored tracks, every song, songs on loop, errors)

```
